### PR TITLE
Doc updates

### DIFF
--- a/docs/27-development/15-acornfile.md
+++ b/docs/27-development/15-acornfile.md
@@ -1,0 +1,112 @@
+---
+title: Configure Acornfile Dev Settings 
+---
+
+## Overview
+
+Applications have different settings when running in development vs production. Acorn supports providing different values in production and development directly in the Acornfile. The top-level `profiles` key lets the author define different values for different scenarios. Each profile can specify a different default value for the arguments defined by the Acornfile.
+
+In the case of development versus running the application in a non-development setting there is a built-in boolean argument `args.dev` that is true when Acorn is run in development mode.
+
+## Development vs Production Acornfile
+
+Several popular frameworks have development servers that run on a non-production port and provide support for the hot-reloading of source files during development. For example, the static website-generating app Hugo has a development server that runs on port 1313 and automatically generates a new version of the site when a source file is changed.
+
+Let's take a look at a sample Hugo development setup with Acorn. The Dockerfile for the Hugo site looks like:
+
+```docker
+FROM klakegg/hugo:0.101.0-alpine as hugo
+
+ADD ./ /src
+WORKDIR /src
+
+EXPOSE 1313
+CMD [ "server", "--bind", "0.0.0.0", "-D" ]
+```
+
+To support development
+
+```acorn
+containers: {
+    site: {
+        build: {
+            context: "."
+        }
+        ports: publish: "1313/http"
+        dirs: {
+            "/src": "./"
+        }
+    }
+}
+```
+
+In the setup above the Acornfile is set up to support the Hugo Docker development workflow. It will synchronize the files in the current directory to the `/src` directory in the container. As files are changing the developer will be able to review them in the browser by navigating to the Acorn provided URL.
+
+This works for development, but when it comes time to publish the site to a production environment meant for users to access it, there are different settings and configurations needed. In this example, the site should be hosted from a web server like Nginx and on standard web ports.
+
+Using the features of Acorn and multi-stage Docker builds we can create a setup that will work for both development and production in a single Acornfile.
+
+First, update the Dockerfile to support a `static` mode that will host the built site in Nginx.
+
+```docker
+FROM klakegg/hugo:0.111.3-alpine AS hugo
+
+ADD ./ /src
+WORKDIR /src
+RUN mkdir -p /target && \
+    hugo -d /target/ --minify
+
+FROM nginx AS static
+COPY --from=hugo /target /usr/share/nginx/html
+
+FROM hugo AS dev
+EXPOSE 1313
+CMD [ "server", "--bind", "0.0.0.0", "-D" ]
+```
+
+In the Dockerfile above we set up a base target called `hugo` along with a development `dev` and `static` production target. The `hugo` target will always build the contents of the site and the other targets will determine how the site is served up.
+
+Now that the Dockerfile is prepared, we can update the Acornfile to support the different scenarios. We will use the built-in `args.dev` to configure the build target, port, and if files should be synchronized.
+
+```acorn
+containers: {
+    site: {
+        build: {
+            context: "."
+            target: std.ifelse(args.dev, "dev", "static")
+        }
+        ports: publish: std.ifelse(args.dev, "1313/http","80/http")
+        if args.dev {
+            dirs: {
+                "/src": "./"
+            }
+        }
+    }
+}
+```
+
+In the above Acornfile, we are now using the `args.dev` argument to determine how to deploy our application. When a developer wishes to make changes and develop locally, they run `acorn dev .` and the Acornfile will be run in development mode. When it is time to publish the site a normal `acorn build .` will build the site into the `static` target ready to be deployed into a production environment.
+
+## Using a Debugger
+
+Acorn supports defining ports to attach debuggers when in development mode. When a `dev` port is defined Acorn will create a port-forward from localhost to the remote container. This allows you to attach a debugger to the application running in the container. The port is always defined as TCP and will be available on localhost.
+
+For example setting up Node.js debugging tools could be done like this.
+
+```acorn
+containers: {
+    app: {
+        build: {
+            context: "."
+        }
+        // ...
+        ports: dev: "9229"
+        if args.dev {
+            command: ["node", "--inspect=0.0.0.0:9229"]
+        }
+        // ...
+    }
+}
+```
+
+**Note:** This would require a node.js app to be configured to run in the container.

--- a/docs/50-advanced/05-publishing.md
+++ b/docs/50-advanced/05-publishing.md
@@ -1,5 +1,5 @@
 ---
-title: Publishing Acorn Images
+title: Building and Publishing Acorn Images
 ---
 
 Once the application is in a state where it is ready to move to test and production you will need to build an Acorn image and publish it to a registry. Acorn images are only accessible to the Acorn namespace they were built in. In order to use them in other namespaces or on other Kubernetes clusters, the images need to be tagged and published to a registry.

--- a/docs/60-authoring/05-secrets.md
+++ b/docs/60-authoring/05-secrets.md
@@ -34,6 +34,55 @@ secrets: {
 
 The example shows the secret `db-root-password` being consumed as an environment variable in the db container. The secret is of type token and will automatically be generated at runtime by Acorn. The user can then use the Acorn CLI to get the credential if needed.
 
+### Consume all secret keys as environment variables
+
+Sometimes you have multiple secrets that need to be consumed as environment variables. The example below shows how to consume all the values in a secret as environment variables named after the keys. The keys must be set exactly as you want them to show up in the environment
+
+```acorn
+containers: app: {
+    image: "mysql"
+    env: {
+        "secret://mysql-info": ""
+    }
+}
+
+secrets: "mysql-info": {
+    type: "opaque"
+    data: {
+        "MYSQL_ROOT_PASSWORD": "Foo"
+    }
+}
+```
+
+This will set the environment variable "MYSQL_ROOT_PASSWORD" to the value "Foo" in the container.
+
+This is really beneficial if you need to consume somewhat arbitrary secret data as environment variables. Take an app that will run a 3rd party script that requires unknown environment variables. The user can bind in a secret at deploy time that has the needed info.
+
+```acorn
+containers: nginx: {
+    image: "nginx"
+    env: "secret://php-env-vars": ""
+}
+
+secrets: "php-env-vars": {
+    type: "opaque"
+}
+```
+
+Now if the user creates a secret like:
+
+```shell
+acorn secret create php-env-vars --data PHP_ENV_VAR1=foo --data PHP_ENV_VAR2=bar
+```
+
+Then runs the acorn like so from the directory with the Acornfile:
+
+```shell
+acorn run -n php-app -s php-env-vars:php-env-vars .
+```
+
+The nginx container will have the env vars.
+
 ### Consuming secrets in templates
 
 Secrets in templates are wrapped in `${}`. It is possible to pass secret configuration data to a container in a pre-rendered form. This next example shows how you can add a configuration file with sensitive data.

--- a/sidebars.js
+++ b/sidebars.js
@@ -41,6 +41,7 @@ const sidebars = {
       "label": "Developing with Acorn",
       items: [
         "development/dev-mode",
+        "development/acornfile",
         "development/vsc",
       ]
     },


### PR DESCRIPTION
Updated title for publishing to make it clear it also covers builds.
Added dev mode Acornfile docs along with debug ports.
Added docs to cover mapping secret keys and values to  env vars.