### PR TITLE
Fix hyperlink in same category

### DIFF
--- a/docs/60-authoring/03-containers.md
+++ b/docs/60-authoring/03-containers.md
@@ -35,7 +35,7 @@ Now when `acorn build .` or `acorn run -i .` is run, the `my-app` container will
 
 ### Customized build behavior
 
-Acorn provides options to customize the building of OCI images. If the Dockerfile is not in the root directory of the `context` you can specify the location using the `dockerfile` parameter. If the image is a multi-stage build, the desired target can be specified. See [args and profiles](authoring/args-and-profiles) to see how to customize these values at build and runtime.
+Acorn provides options to customize the building of OCI images. If the Dockerfile is not in the root directory of the `context` you can specify the location using the `dockerfile` parameter. If the image is a multi-stage build, the desired target can be specified. See [args and profiles](args-and-profiles) to see how to customize these values at build and runtime.
 
 ```acorn
 containers: {
@@ -204,7 +204,7 @@ containers: {
 }
 ```
 
-The above example has a `db` container with the `MYSQL_ROOT_PASSWORD` variable set by a [secret](authoring/secrets) in the Acornfile. The `DATABASE_NAME` is set to a static value, and the `USER_SET_VALUE` is defined by a user [arg](authoring/args-and-profiles). When launched the container can access these environment variables as needed.
+The above example has a `db` container with the `MYSQL_ROOT_PASSWORD` variable set by a [secret](secrets) in the Acornfile. The `DATABASE_NAME` is set to a static value, and the `USER_SET_VALUE` is defined by a user [arg](args-and-profiles). When launched the container can access these environment variables as needed.
 
 ## Files
 

--- a/docs/60-authoring/05-secrets.md
+++ b/docs/60-authoring/05-secrets.md
@@ -209,7 +209,7 @@ secrets: {
 }
 ```
 
-In the above example the secret renders a template secret with one key called "password.txt", consuming the token from the secret named "token." See [advanced topics](authoring/advanced) for other uses for the template secret type.
+In the above example the secret renders a template secret with one key called "password.txt", consuming the token from the secret named "token." See [advanced topics](advanced) for other uses for the template secret type.
 
 ### Token secrets
 
@@ -236,7 +236,7 @@ The `token` field in the data object is optional and needs to be left the defaul
 
 ### Generated secrets
 
-Generated secrets allow storing sensitive data output from a [job](authoring/jobs).
+Generated secrets allow storing sensitive data output from a [job](jobs).
 
 ```acorn
 containers: {


### PR DESCRIPTION
Hi team,

I was searching in the docs and noticed some dead hyperlinks in the /authoring category. Which you can reproduce by going to https://docs.acorn.io/authoring/containers#customized-build-behavior and then clicking the hyperlink "[args and profiles](https://docs.acorn.io/authoring/authoring/args-and-profiles)". This will route you to https://docs.acorn.io/authoring/authoring/args-and-profiles, notice the double /authoring/authoring in the URI. I checked all the categories (dirs in https://github.com/acorn-io/docs/tree/main/docs) and fixed a few of these links using "acorn dev", which was really cool to use :).