### PR TITLE
fix: update compute class documentation to be in line with sandbox/pro current state

### DIFF
--- a/docs/30-production/05-acorn-sizing.md
+++ b/docs/30-production/05-acorn-sizing.md
@@ -12,12 +12,9 @@ In order to see what compute classes are available to use in your project, you c
 
 ```shell
 acorn offerings computeclasses
-# NAME      DEFAULT   MEMORY RANGE   MEMORY DEFAULT   REGIONS                                               DESCRIPTION
-# c5                  128Mi-14Gi     512Mi            aws-us-east-2                                         Compute optimized AWS instances (c5)
-# default   *         128Mi-14Gi     512Mi            aws-us-east-2,acorn-gp-us-east-2,acorn-sb-us-east-2   Default compute class
-# m5                  128Mi-14Gi     512Mi            aws-us-east-2                                         General purpose AWS instances (m5)
-# r5                  128Mi-62Gi     512Mi            aws-us-east-2                                         Memory optimized AWS instances (r5)
-# t3                  128Mi-14Gi     512Mi            aws-us-east-2                                         Burstable AWS instances (t3)
+# NAME      DEFAULT   MEMORY RANGE   MEMORY DEFAULT   REGIONS                                 DESCRIPTION
+# free      *         128Mi-380Gi    512Mi            acorn-gp-us-east-2,acorn-gp-us-west-2   Free tier compute class
+# standard            128Mi-380Gi    512Mi            acorn-gp-us-east-2,acorn-gp-us-west-2   Standard tier compute class
 ```
 
 | **NOTE:** *The output might be different depending on your project, region and plan.*
@@ -25,30 +22,30 @@ acorn offerings computeclasses
 This produces a list of available compute classes available. The default ComputeClass is marked with a `*`. When running your application you can specify the compute class you want to use with the `--compute-class` flag.
 
 ```shell
-acorn run --compute-class m5 ghcr.io/acorn-io/hello-world
+acorn run --compute-class free ghcr.io/acorn-io/hello-world
 ```
 
-The above example will launch the hello world acorn on an m5 type of machine. While possible, we don't recommend specifying a ComputeClass in an Acornfile that is intended to share. This is because the ComputeClass might not be defined in everyone's projects. Instead, we recommend specifying the ComputeClass when running the Acorn, and in Acornfiles used to define your specific deployment through nested acorns.
+The above example will launch the hello world acorn on a free type of machine. While possible, we don't recommend specifying a ComputeClass in an Acornfile that is intended to share. This is because the ComputeClass might not be defined in everyone's projects. Instead, we recommend specifying the ComputeClass when running the Acorn, and in Acornfiles used to define your specific deployment through nested acorns.
 
 ### Change Existing Acorn ComputeClass
 
 In order to adjust an existing Acorn's ComputeClass, you can use the `update` command.
 
-For example if we use our running hello-world app from above that was launched with the `m5` compute class we can change it to a `t3` compute class with the following command:
+For example if we use our running hello-world app from above that was launched with the `free` compute class we can change it to a `standard` compute class with the following command:
 
 ```shell
-acorn update --compute-class t3 hello-world
+acorn update --compute-class standard hello-world
 ```
 
-This will relaunch the Acorn on a `t3` compute class with the same args and defaults as the original command.
+This will relaunch the Acorn on a `standard` compute class with the same args and defaults as the original command.
 
 ## Memory Presets and Customizations
 
 You can also specify the memory for your Acorn within the memory range of the compute class. For example the default compute class from above:
 
 ```shell
-NAME      DEFAULT   MEMORY RANGE   MEMORY DEFAULT   REGIONS                                               DESCRIPTION
-default   *         128Mi-14Gi     512Mi            aws-us-east-2,acorn-gp-us-east-2,acorn-sb-us-east-2   Default compute class
+NAME      DEFAULT   MEMORY RANGE   MEMORY DEFAULT   REGIONS                                 DESCRIPTION
+free      *         128Mi-380Gi    512Mi            acorn-gp-us-east-2,acorn-gp-us-west-2   Free tier compute class
 ```
 
 Automatically sets the memory requests to 512Mi. If you find that your application needs more memory, you can specify the memory with the `--memory` flag.
@@ -104,19 +101,19 @@ When describing an Acorn deployment in an Acornfile, you can specify the compute
 
 ```acorn
 services: mariadb: {
-    class: "m5"
+    class: "standard"
     image: "ghcr.io/acorn-io/mariadb:v10.#.#-#"
     autoUpgrade: true
 }
 
 acorns: app: {
-    class: "c5"
+    class: "free"
     image: "ghcr.io/acorn-io/hello-world:v1.#.#"
     autoUpgrade: true
 }
 ```
 
-In this example, the `mariadb` service will be deployed on an `m5` compute class and the `app` acorn will be deployed on a `c5` compute class. If you don't specify a compute class, the default compute class will be used, same as on the command line.
+In this example, the `mariadb` service will be deployed on an `standard` compute class and the `app` acorn will be deployed on a `free` compute class. If you don't specify a compute class, the default compute class will be used, same as on the command line.
 
 ### On a container
 
@@ -125,8 +122,8 @@ This is possible, but not recommended. If you want to specify a compute class fo
 ```acorn
 containers: nginx: {
     image: "nginx"
-    class: "t3"
+    class: "standard"
 }
 ```
 
-In this example, the `nginx` container will be deployed on a `t3` compute class. If you don't specify a compute class, the default compute class will be used, same as on the command line.
+In this example, the `nginx` container will be deployed on a `standard` compute class. If you don't specify a compute class, the default compute class will be used, same as on the command line.

--- a/docs/30-production/05-acorn-sizing.md
+++ b/docs/30-production/05-acorn-sizing.md
@@ -107,13 +107,13 @@ services: mariadb: {
 }
 
 acorns: app: {
-    class: "free"
+    class: "standard"
     image: "ghcr.io/acorn-io/hello-world:v1.#.#"
     autoUpgrade: true
 }
 ```
 
-In this example, the `mariadb` service will be deployed on an `standard` compute class and the `app` acorn will be deployed on a `free` compute class. If you don't specify a compute class, the default compute class will be used, same as on the command line.
+In this example, both the `mariadb` service and the `app` acorn will be deployed on an `standard` compute class. If you don't specify a compute class, the default compute class will be used, same as on the command line.
 
 ### On a container
 


### PR DESCRIPTION
Update with naming scheme of `free` and `standard` with `free` as the default. Remove references of byoc compute class offerings.